### PR TITLE
Support multiple signatures from one data packet request

### DIFF
--- a/docs/datapackettestmobile.md
+++ b/docs/datapackettestmobile.md
@@ -331,3 +331,58 @@ For each row where a flag is set, the corresponding data/constraint from Section
 6. **`FLAG_HAS_URL_FOR_DOWNLOAD`**: download from URL in `signableObjects`; verify hash if present; reject on hash mismatch.
 7. **`FLAG_HAS_SIGNATURE`**: verify the embedded inner signature; display result to user.
 8. Handle **all combinations** — flags are a bitmask and any subset of the six flags can be active simultaneously.
+9. **Multi-object downloads**: a downloaded packet may resolve to several objects that each need their own signature — see Section 10.
+
+---
+
+## 10. Multiple Signatures From One Request
+
+`FLAG_HAS_URL_FOR_DOWNLOAD` + `FLAG_FOR_USERS_SIGNATURE` (flags `0x28`, plus request ID and statements in practice: `0x2B`) does not have to describe a single blob. The URL may resolve to a `DataDescriptor` whose `objectdata` is a `VdxfUniValue` containing **one nested `DataDescriptor` per object the user is asked to sign**. A batch of endorsements is the first use of this shape:
+
+```
+DataDescriptor                       (downloaded from URLRef.url, hash-verified)
+ ├─ label: "ValuVerse Endorsements"
+ └─ objectdata: VdxfUniValue
+      ├─ [DataDescriptorKey] DataDescriptor  mimetype application/json  → endorsement 1
+      ├─ [DataDescriptorKey] DataDescriptor  mimetype application/json  → endorsement 2
+      └─ [DataDescriptorKey] DataDescriptor  mimetype application/json  → endorsement 3
+```
+
+### 10.1 Wallet behaviour
+
+1. Download and hash-verify as described in Section 5.6.
+2. Parse the packet's `objectdata` as a `VdxfUniValue` and collect every nested `DataDescriptor`. If none are found, handle the packet as a single object (existing behaviour).
+3. Render each nested object for review. `application/json` payloads are shown field by field; `text/*` payloads are shown as text. The nested `label` is a VDXF key and is resolved to a friendly name through the signer's `DefinedKey` content where possible.
+4. Let the user select which objects to sign. All are selected by default; continuing with none selected is rejected.
+5. Sign **each selected object independently**: `signatureHash = SHA-256(nestedDescriptor.toBuffer())`, then the usual VerusID identity hash (`version 2`, `hash_type 5`, current height) and `signHash`.
+
+When the packet holds no nested descriptors, the whole `DataPacketRequestDetails` buffer is signed instead, exactly as in Section 5.4.
+
+### 10.2 Response shape
+
+All signatures ride in **one** `DataResponseDetails`, inside a single `VdxfUniValue` as interleaved `[DataDescriptorKey, SignatureDataKey]` pairs. Each signature immediately follows the exact bytes it covers, so the requester can attribute a signature without reconstructing the downloaded packet byte for byte:
+
+```
+GenericResponse
+ ├─ requestID          (echoed from DataPacketRequestDetails.requestID)
+ ├─ signature          (VerifiableSignatureData - outer signature over the whole response)
+ └─ details[]
+      └─ DataResponseOrdinalVDXFObject
+           └─ data: DataResponseDetails
+                ├─ requestid
+                └─ data: DataDescriptor (FLAG_SALT_PRESENT)
+                     └─ objectdata: VdxfUniValue
+                          ├─ [DataDescriptorKey] endorsement 1
+                          ├─ [SignatureDataKey]  signature over SHA-256(endorsement 1 bytes)
+                          ├─ [DataDescriptorKey] endorsement 3
+                          └─ [SignatureDataKey]  signature over SHA-256(endorsement 3 bytes)
+```
+
+Deselected objects are absent from the response entirely. The response is delivered to `GenericRequest.responseURIs` as usual (Section 3.3).
+
+### 10.3 Verification checklist for the requester
+
+- [ ] Pairs appear in the same relative order as the published packet, with deselected objects omitted.
+- [ ] For each pair, `SHA-256(descriptor.toBuffer())` equals the paired `SignatureData.signatureHash`.
+- [ ] Each `SignatureData.identityID` / `systemID` matches the outer response signer.
+- [ ] Each signature verifies against the VerusID identity hash at the height reported by `getsignatureinfo`.

--- a/src/containers/DeepLink/DataPacketRequestInfo/DataPacketRequestInfo.js
+++ b/src/containers/DeepLink/DataPacketRequestInfo/DataPacketRequestInfo.js
@@ -56,7 +56,16 @@ import { modifyAttestationDataForUser } from '../../../actions/actions/attestati
 import SemiModal from '../../../components/SemiModal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import axios from 'axios';
+import {
+  describeSignableObject,
+  extractSignableDescriptors,
+  getSignableObjectTitle,
+} from '../../../utils/deeplink/signableObjects';
 const crypto = require('create-hash');
+
+// Marker mime type used internally once a downloaded packet has been resolved
+// into a list of individually signable objects (e.g. a batch of endorsements).
+const SIGNABLE_OBJECTS_MIME_TYPE = 'application/signable-objects';
 
 // Data packet storage type constant
 const DATA_PACKETS_RECEIVED = "data_packets_received";
@@ -283,8 +292,70 @@ const IdentityPickerSheet = ({
   );
 };
 
+// List of individually signable objects from a downloaded packet. Each row can
+// be toggled, and the selected rows are the ones that get signed.
+const SignableObjectList = ({ objects, selectedIndices, labels, onToggle }) => {
+  if (!objects || objects.length === 0) return null;
+
+  return (
+    <View style={styles.signableList}>
+      {objects.map((object, position) => {
+        const isSelected = selectedIndices.includes(object.index);
+        const title = getSignableObjectTitle(object, labels?.[object.label]);
+
+        return (
+          <TouchableOpacity
+            key={`signable-${object.index}`}
+            style={[
+              styles.signableItem,
+              position > 0 && styles.signableItemBorder,
+              isSelected && styles.signableItemSelected,
+            ]}
+            onPress={onToggle ? () => onToggle(object.index) : undefined}
+            activeOpacity={onToggle ? 0.7 : 1}
+          >
+            <View style={styles.signableItemHeader}>
+              <MaterialCommunityIcons
+                name={
+                  onToggle
+                    ? (isSelected ? 'checkbox-marked' : 'checkbox-blank-outline')
+                    : 'file-document-outline'
+                }
+                size={22}
+                color={onToggle && isSelected ? Colors.verusGreenColor : '#BBB'}
+              />
+              <Text style={styles.signableItemTitle} numberOfLines={2}>
+                {title}
+              </Text>
+            </View>
+
+            {object.fields.length > 0 ? (
+              <View style={styles.signableItemBody}>
+                {object.fields.map(field => (
+                  <View key={field.key} style={styles.signableFieldRow}>
+                    <Text style={styles.signableFieldLabel}>{field.label}</Text>
+                    <Text style={styles.signableFieldValue} numberOfLines={2}>
+                      {field.value}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <View style={styles.signableItemBody}>
+                <Text style={styles.signableFieldValue} numberOfLines={4}>
+                  {object.text || `${object.mimeType || 'Binary data'} (${object.buffer.length} bytes)`}
+                </Text>
+              </View>
+            )}
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
 // URL Download Modal
-const UrlDownloadModal = ({ 
+const UrlDownloadModal = ({
   visible, 
   url, 
   onClose, 
@@ -301,15 +372,20 @@ const UrlDownloadModal = ({
   onAcceptAttestation,
   onRejectAttestation,
   onDescriptorPress,
+  signableObjects,
+  selectedSignableIndices,
+  signableObjectLabels,
+  onToggleSignableObject,
 }) => {
   const insets = useSafeAreaInsets();
-  
+
   if (!visible) return null;
-  
+
   const isTextContent = contentMimeType?.startsWith('text/');
   const isImageContent = contentMimeType?.startsWith('image/');
   const isAttestation = contentMimeType === 'application/attestation';
-  
+  const isSignableObjects = contentMimeType === SIGNABLE_OBJECTS_MIME_TYPE;
+
   return (
     <Portal>
       <SemiModal
@@ -384,6 +460,22 @@ const UrlDownloadModal = ({
                 </View>
               )}
               
+              {isSignableObjects && (
+                <View style={styles.signablePreviewContainer}>
+                  <MaterialCommunityIcons name="file-document-edit-outline" size={24} color={Colors.primaryColor} />
+                  <Text style={styles.attestationSuccessText}>{downloadedContent}</Text>
+                  <Text style={styles.signablePreviewHint}>
+                    Every selected item is signed separately.
+                  </Text>
+                  <SignableObjectList
+                    objects={signableObjects}
+                    selectedIndices={selectedSignableIndices || []}
+                    labels={signableObjectLabels}
+                    onToggle={onToggleSignableObject}
+                  />
+                </View>
+              )}
+
               {isTextContent && !isAttestation && (
                 <View style={styles.textContentPreview}>
                   <Text style={styles.previewLabel}>Content Preview:</Text>
@@ -511,6 +603,18 @@ const DataPacketRequestInfo = props => {
   const [pendingAttestationSigner, setPendingAttestationSigner] = useState(null);
   const [attestationAccepted, setAttestationAccepted] = useState(false);
 
+  // Individually signable objects parsed out of a downloaded packet. A packet
+  // can hold several (e.g. a batch of endorsements) and the user picks which
+  // ones to sign, so one request can return more than one signature.
+  const [signableObjects, setSignableObjects] = useState([]);
+  const [selectedSignableIndices, setSelectedSignableIndices] = useState([]);
+  const [signableObjectLabels, setSignableObjectLabels] = useState({});
+
+  const selectedSignableObjects = useMemo(
+    () => signableObjects.filter(object => selectedSignableIndices.includes(object.index)),
+    [signableObjects, selectedSignableIndices],
+  );
+
   const insets = useSafeAreaInsets();
 
   const accounts = useObjectSelector(state => state.authentication.accounts);
@@ -629,42 +733,62 @@ const DataPacketRequestInfo = props => {
 
     try {
       setLoading(true);
-      
+
       const { chainId, iAddress } = selectedIdentity;
       const coinObjForSign = CoinDirectory.findCoinObj(chainId, null, true);
       const systemId = coinObjForSign.system_id;
-      
+
       // Get current chain height
       const chainInfo = await getInfo(systemId);
       if (chainInfo.error) throw new Error(chainInfo.error.message);
       const height = chainInfo.result.longestchain;
-      
-      // Hash the entire DataPacketRequestDetails buffer
-      const detailsBuffer = details.toBuffer();
-      const signatureHash = crypto('sha256').update(detailsBuffer).digest();
-      
-      // Create SignatureData object
-      const sigData = new SignatureData({
-        version: new BN(1),
-        systemID: systemId,
-        identityID: iAddress,
-        signatureHash: signatureHash,
-        hashType: new BN(5), // SHA256
-        sigType: new BN(1), // TYPE_VERUSID_DEFAULT
-      });
-      
-      // Get the identity hash for signing
-      const sigHash = sigData.getIdentityHash({ version: 2, hash_type: 5, height });
-      
-      // Sign the hash
-      const signature = await signHash(coinObjForSign, iAddress, sigHash, height);
-      sigData.signatureAsVch = Buffer.from(signature, 'base64');
-      
-      // Create VdxfUniValue with SignatureData
+
+      // Produces one SignatureData over an arbitrary buffer with the selected
+      // identity. Used once per object so a request can carry many signatures.
+      const signBuffer = async (buffer) => {
+        const sigData = new SignatureData({
+          version: new BN(1),
+          systemID: systemId,
+          identityID: iAddress,
+          signatureHash: crypto('sha256').update(buffer).digest(),
+          hashType: new BN(5), // SHA256
+          sigType: new BN(1), // TYPE_VERUSID_DEFAULT
+        });
+
+        // Get the identity hash for signing
+        const sigHash = sigData.getIdentityHash({ version: 2, hash_type: 5, height });
+
+        // Sign the hash
+        const signature = await signHash(coinObjForSign, iAddress, sigHash, height);
+        sigData.signatureAsVch = Buffer.from(signature, 'base64');
+
+        return sigData;
+      };
+
+      // Create VdxfUniValue with the SignatureData for every signed object
       const dataKeyMap = [];
-      dataKeyMap.push({ [VDXF_Data.SignatureDataKey.vdxfid]: sigData });
+
+      if (selectedSignableObjects.length > 0) {
+        // A downloaded packet resolved into individual objects: each one is
+        // signed on its own. The signed bytes are emitted next to their
+        // signature so the requester can match each signature to its object
+        // without reconstructing the downloaded packet byte for byte.
+        for (const signableObject of selectedSignableObjects) {
+          const sigData = await signBuffer(signableObject.buffer);
+
+          dataKeyMap.push({ [VDXF_Data.DataDescriptorKey.vdxfid]: signableObject.descriptor });
+          dataKeyMap.push({ [VDXF_Data.SignatureDataKey.vdxfid]: sigData });
+        }
+      } else {
+        // No individually signable objects - sign the whole
+        // DataPacketRequestDetails buffer.
+        const sigData = await signBuffer(details.toBuffer());
+
+        dataKeyMap.push({ [VDXF_Data.SignatureDataKey.vdxfid]: sigData });
+      }
+
       const signatureUniValue = new VdxfUniValue({ values: dataKeyMap });
-      
+
       // Create nested DataDescriptor with signature
       const nestedDescriptor = DataDescriptor.fromJson({
         version: 1,
@@ -1157,10 +1281,21 @@ const DataPacketRequestInfo = props => {
     setPendingAttestationDescriptors([]);
     setPendingAttestationSigner(null);
     setAttestationAccepted(false);
+    setSignableObjects([]);
+    setSelectedSignableIndices([]);
+    setSignableObjectLabels({});
     setDownloadedContent(null);
     setContentMimeType(null);
     setHashVerified(null);
     setUrlDownloadModalVisible(false);
+  };
+
+  const handleToggleSignableObject = (index) => {
+    setSelectedSignableIndices(current =>
+      current.includes(index)
+        ? current.filter(selected => selected !== index)
+        : [...current, index].sort((a, b) => a - b),
+    );
   };
 
   // Download data from URL and verify hash
@@ -1209,14 +1344,15 @@ const DataPacketRequestInfo = props => {
       // Try to parse as DataDescriptor first
       let downloadedDescriptor = null;
       let attestationData = null;
+      let signableObjectData = null;
       let mimeType = 'text/plain';
       let content = '';
-      
+
       try {
         downloadedDescriptor = new DataDescriptor();
         downloadedDescriptor.fromBuffer(dataBuffer);
         setDownloadedDataDescriptor(downloadedDescriptor);
-        
+
         // Check if this is an attestation (no mimetype and contains UniValue objects).
         // A packet may carry more than one attestation, so this returns an array.
         if (!downloadedDescriptor.mimeType || downloadedDescriptor.mimeType === '') {
@@ -1248,9 +1384,32 @@ const DataPacketRequestInfo = props => {
             attestationData = payloads[0];
           }
         }
-        
-        // If not an attestation, process as regular content
+
+        // Not an attestation, but the packet may still hold a list of nested
+        // descriptors the user is being asked to sign individually - for
+        // example a batch of endorsements. Each one becomes its own signature.
         if (!attestationData) {
+          const nestedDescriptors = extractSignableDescriptors(downloadedDescriptor);
+
+          if (nestedDescriptors.length > 0) {
+            const objects = nestedDescriptors.map(describeSignableObject);
+
+            setSignableObjects(objects);
+            // Everything the sender included is selected by default; the user
+            // can deselect individual objects before signing.
+            setSelectedSignableIndices(objects.map(object => object.index));
+            setSignableObjectLabels(await resolveSignerDefinedKeyLabels());
+
+            mimeType = SIGNABLE_OBJECTS_MIME_TYPE;
+            content = objects.length > 1
+              ? `Review these ${objects.length} items before signing.`
+              : 'Review this item before signing.';
+            signableObjectData = objects;
+          }
+        }
+
+        // If not an attestation or a signable object list, process as regular content
+        if (!attestationData && !signableObjectData) {
           mimeType = downloadedDescriptor.mimeType || 'application/octet-stream';
           
           if (mimeType && mimeType.startsWith('text/')) {
@@ -1325,6 +1484,13 @@ const DataPacketRequestInfo = props => {
 
       if (hasUrlDownload && pendingAttestationData && !attestationAccepted) {
         createAlert('Acceptance Required', 'Please review and accept the attestation before continuing.');
+        return;
+      }
+
+      // A signature is produced per selected object, so at least one has to be
+      // selected for there to be anything to return.
+      if (isForUserSig && signableObjects.length > 0 && selectedSignableObjects.length === 0) {
+        createAlert('Nothing Selected', 'Select at least one item to sign before continuing.');
         return;
       }
 
@@ -1592,6 +1758,19 @@ const DataPacketRequestInfo = props => {
       });
     }
 
+    // One signature is produced per selected downloaded object
+    if (signableObjects.length > 0 && isForUserSignature) {
+      rows.push({
+        key: 'signature-count',
+        title: `${selectedSignableObjects.length} of ${signableObjects.length} selected to sign`,
+        subtitle: selectedSignableObjects.length === 1
+          ? 'One signature will be returned.'
+          : `${selectedSignableObjects.length} signatures will be returned.`,
+        rightIcon: selectedSignableObjects.length > 0 ? 'pen' : 'alert-circle-outline',
+        isError: selectedSignableObjects.length === 0,
+      });
+    }
+
     // Request ID
     if (hasRequestId && details.requestID) {
       const requestIdDisplay = details.requestID.toIAddress ? details.requestID.toIAddress() : 'Unknown';
@@ -1664,7 +1843,7 @@ const DataPacketRequestInfo = props => {
     }
 
     return rows;
-  }, [details, hasRequestId, hasStatements, hasSignature, isForUserSignature, isForTransmittalToUser, hasUrlForDownload, embeddedIsSignatureValid, embeddedSignerFqn, embeddedSignerIdentityID, embeddedChainId, embeddedSigDateString, canOpenEmbeddedSignerModal, urlRef, hashVerified, recipientConstraintIds, recipientId, linkedIds]);
+  }, [details, hasRequestId, hasStatements, hasSignature, isForUserSignature, isForTransmittalToUser, hasUrlForDownload, embeddedIsSignatureValid, embeddedSignerFqn, embeddedSignerIdentityID, embeddedChainId, embeddedSigDateString, canOpenEmbeddedSignerModal, urlRef, hashVerified, recipientConstraintIds, recipientId, linkedIds, signableObjects, selectedSignableObjects]);
 
   // Determine if continue button should be disabled
   const continueDisabled = useMemo(() => {
@@ -1672,9 +1851,10 @@ const DataPacketRequestInfo = props => {
     if (isForUserSignature && !selectedIdentity && signedIn) return true;
     if (hasUrlForDownload && hashVerified !== true && signedIn) return true;
     if (hasUrlForDownload && pendingAttestationData && !attestationAccepted && signedIn) return true;
+    if (isForUserSignature && signableObjects.length > 0 && selectedSignableObjects.length === 0 && signedIn) return true;
     if (isForTransmittalToUser && recipientConstraintIds.size > 0 && !recipientId && signedIn) return true;
     return false;
-  }, [isSigned, embeddedIsSignatureValid, isForUserSignature, selectedIdentity, signedIn, hasUrlForDownload, hashVerified, pendingAttestationData, attestationAccepted, isForTransmittalToUser, recipientConstraintIds, recipientId]);
+  }, [isSigned, embeddedIsSignatureValid, isForUserSignature, selectedIdentity, signedIn, hasUrlForDownload, hashVerified, pendingAttestationData, attestationAccepted, isForTransmittalToUser, recipientConstraintIds, recipientId, signableObjects, selectedSignableObjects]);
 
   // Determine hero text based on request type
   const getHeroTitle = () => {
@@ -1685,7 +1865,12 @@ const DataPacketRequestInfo = props => {
   };
 
   const getHeroSubtitle = () => {
-    if (isForUserSignature) return 'Sign the included data';
+    if (isForUserSignature) {
+      if (signableObjects.length > 1) {
+        return `Sign ${selectedSignableObjects.length} of ${signableObjects.length} items`;
+      }
+      return 'Sign the included data';
+    }
     if (isForTransmittalToUser) return 'Review and save data';
     if (hasUrlForDownload) return 'Download and verify data';
     return 'Review data packet';
@@ -1732,6 +1917,10 @@ const DataPacketRequestInfo = props => {
           ? `${pendingAttestations.length} attestations`
           : pendingAttestationData?.label}
         attestationSigner={pendingAttestationSigner}
+        signableObjects={signableObjects}
+        selectedSignableIndices={selectedSignableIndices}
+        signableObjectLabels={signableObjectLabels}
+        onToggleSignableObject={handleToggleSignableObject}
         onAcceptAttestation={handleAcceptDownloadedAttestation}
         onRejectAttestation={handleRejectDownloadedAttestation}
         onDescriptorPress={(descriptor) => {
@@ -1883,6 +2072,35 @@ const DataPacketRequestInfo = props => {
             )}
           </View>
         </View>
+
+        {/* Downloaded objects, each signed separately */}
+        {signableObjects.length > 0 && (
+          <View style={styles.sectionCard}>
+            <View style={styles.sectionHeader}>
+              <View style={styles.sectionHeaderLeft}>
+                <MaterialCommunityIcons name="file-document-edit-outline" size={20} color="#666" />
+                <Text style={styles.sectionTitle}>
+                  {isForUserSignature ? 'Items to sign' : 'Downloaded items'}
+                </Text>
+              </View>
+              <View style={styles.objectCountBadge}>
+                <Text style={styles.objectCountText}>
+                  {isForUserSignature
+                    ? `${selectedSignableObjects.length}/${signableObjects.length}`
+                    : signableObjects.length}
+                </Text>
+              </View>
+            </View>
+            <View style={styles.sectionContent}>
+              <SignableObjectList
+                objects={signableObjects}
+                selectedIndices={selectedSignableIndices}
+                labels={signableObjectLabels}
+                onToggle={isForUserSignature ? handleToggleSignableObject : undefined}
+              />
+            </View>
+          </View>
+        )}
 
         {/* Data Objects Section */}
         {details.signableObjects && details.signableObjects.length > 0 && !hasUrlForDownload && (
@@ -2511,6 +2729,67 @@ const styles = StyleSheet.create({
   },
   rejectDownloadButtonContent: {
     height: 44,
+  },
+  signablePreviewContainer: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    backgroundColor: '#EBF6FF',
+    borderRadius: 12,
+    padding: 16,
+    marginTop: 8,
+    gap: 8,
+  },
+  signablePreviewHint: {
+    fontSize: 12,
+    color: '#555',
+    textAlign: 'center',
+  },
+  signableList: {
+    width: '100%',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+  signableItem: {
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  signableItemBorder: {
+    borderTopWidth: 1,
+    borderTopColor: '#EEE',
+  },
+  signableItemSelected: {
+    backgroundColor: '#F4FBF6',
+  },
+  signableItemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  signableItemTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1A1A1A',
+  },
+  signableItemBody: {
+    marginTop: 8,
+    paddingLeft: 32,
+    gap: 4,
+  },
+  signableFieldRow: {
+    flexDirection: 'column',
+  },
+  signableFieldLabel: {
+    fontSize: 11,
+    color: '#888',
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  signableFieldValue: {
+    fontSize: 13,
+    color: '#333',
   },
 });
 

--- a/src/utils/__tests__/unit/signableObjects.unit.test.js
+++ b/src/utils/__tests__/unit/signableObjects.unit.test.js
@@ -1,0 +1,278 @@
+import {
+  describeSignableObject,
+  extractSignableDescriptors,
+  getSignableObjectTitle,
+  objectDataToBuffer,
+} from '../../deeplink/signableObjects';
+import {
+  CompactAddressObject,
+  DataDescriptor,
+  DataPacketRequestDetails,
+  DataResponseDetails,
+  DataResponseOrdinalVDXFObject,
+  DATA_PACKET_REQUEST_VDXF_KEY,
+  GenericRequest,
+  GenericResponse,
+  SignatureData,
+  VdxfUniValue,
+  VerifiableSignatureData,
+} from 'verus-typescript-primitives';
+import * as VDXF_Data from 'verus-typescript-primitives/dist/vdxf/vdxfdatakeys';
+import { BN } from 'bn.js';
+const createHash = require('create-hash');
+
+// Real endorsement request: a GenericRequest carrying a DataPacketRequestDetails
+// with FLAG_HAS_URL_FOR_DOWNLOAD | FLAG_FOR_USERS_SIGNATURE (flags 43) whose
+// URL resolves to the packet in ENDORSEMENT_PACKET_HEX below.
+const ENDORSEMENT_REQUEST_URI =
+  'verus://1/AY8BEAIFAQIa9bgBXGTTmrRMYOrYMX-fWptsTAECOh52NDpjoHHScNeHTxbtJqG4tgNJAgXXsj8AAUEgdEpzWrXiTxmNR2wvJUeZ6McWzCNAePnemPoim_JUjxEiQaSRNJqjMYRbMSoNWFKU7ZcOo4cjNRSxeJGSqIDRRAEC5ixa2yK5y0aNP9sI-ehtpxXgLS7-LodsagICARkCAQEBAotF4_4lucoFPesJ2veAelxMeijVCQG8KwEAAQCI1q5awFcbItFhJhuHx0j24K7gM00BcgICAY_ZHWPXgFQLsf8sOZqT42fdKiXoZHFIIwpsNMmB0OT7Tmh0dHBzOi8vdnJzYy1kZXYudGV4cG8uaW8vYXBpL3YzL29iamVjdHMvZGwvaVFUWnoyakxwTWRpVE0yRjNwa0N2RmJDRnNhR1B6WnNOMgEWVmFsdVZlcnNlIEVuZG9yc2VtZW50cwEC5ixa2yK5y0aNP9sI-ehtpxXgLS4BATVodHRwczovL3Zyc2MtZGV2LnRleHBvLmlvL2FwaS92My9lbmRvcnNlbWVudHNSZXNwb25zZQ';
+
+// The serialized DataDescriptor served by the request's download URL. Its
+// objectdata is a VdxfUniValue holding three nested endorsement descriptors.
+const ENDORSEMENT_PACKET_HEX =
+  '0120fdce0308a2ebb2c55f83a8e2a426a53320ed4d42124f4d01fd2c010160f57b2276657273696f6e223a312c22656e646f72736565223a22694e4e627250374e716d7957794d556b41664b716750516739566331365362444541222c226d657373616765223a22477265617420636f6c6c61626f7261746f72222c227265666572656e6365223a2266616338313661623665333134343163623832326530353730646631623261323138383032306365666365623861636562323538366131333831343432303731222c2274786964223a2238306335353039373033616566326631316461386565316135616533353533333736306232646232376635396264393535396231363966636562373564303036227d2269446250687a6d3867376d513934437932564e6e37644a50566b357a634452685053106170706c69636174696f6e2f6a736f6e08a2ebb2c55f83a8e2a426a53320ed4d42124f4d01fd2d010160f67b2276657273696f6e223a312c22656e646f72736565223a22694e4e627250374e716d7957794d556b41664b716750516739566331365362444541222c226d657373616765223a22477265617420636f6c6c61626f7261746f7232222c227265666572656e6365223a2266616338313661623665333134343163623832326530353730646631623261323138383032306365666365623861636562323538366131333831343432303731222c2274786964223a2238306335353039373033616566326631316461386565316135616533353533333736306232646232376635396264393535396231363966636562373564303036227d2269446250687a6d3867376d513934437932564e6e37644a50566b357a634452685053106170706c69636174696f6e2f6a736f6e08a2ebb2c55f83a8e2a426a53320ed4d42124f4d01fd2d010160f67b2276657273696f6e223a312c22656e646f72736565223a22694e4e627250374e716d7957794d556b41664b716750516739566331365362444541222c226d657373616765223a22477265617420636f6c6c61626f7261746f7233222c227265666572656e6365223a2266616338313661623665333134343163623832326530353730646631623261323138383032306365666365623861636562323538366131333831343432303731222c2274786964223a2238306335353039373033616566326631316461386565316135616533353533333736306232646232376635396264393535396231363966636562373564303036227d2269446250687a6d3867376d513934437932564e6e37644a50566b357a634452685053106170706c69636174696f6e2f6a736f6e1656616c75566572736520456e646f7273656d656e7473';
+
+const SYSTEM_ID = 'i5w5MuNik5NtLcYmNzcvaoixooEebB6MGV';
+const SIGNING_ID = 'iNNbrP7NqmyWyMUkAfKqgPQg9Vc16SbDEA';
+
+const getPacketDescriptor = () => {
+  const descriptor = new DataDescriptor();
+  descriptor.fromBuffer(Buffer.from(ENDORSEMENT_PACKET_HEX, 'hex'));
+  return descriptor;
+};
+
+const getRequestDetails = () => {
+  const request = GenericRequest.fromWalletDeeplinkUri(ENDORSEMENT_REQUEST_URI);
+  const detail = request.details.find(
+    x => x.getIAddressKey() === DATA_PACKET_REQUEST_VDXF_KEY.vdxfid,
+  );
+  return detail.data;
+};
+
+describe('objectDataToBuffer', () => {
+  it('accepts hex strings, Buffers and serialized Buffers', () => {
+    const expected = Buffer.from('deadbeef', 'hex');
+
+    expect(objectDataToBuffer('deadbeef')).toEqual(expected);
+    expect(objectDataToBuffer(expected)).toEqual(expected);
+    expect(objectDataToBuffer({ type: 'Buffer', data: [0xde, 0xad, 0xbe, 0xef] })).toEqual(expected);
+  });
+
+  it('returns null for unusable input', () => {
+    expect(objectDataToBuffer(null)).toBeNull();
+    expect(objectDataToBuffer(undefined)).toBeNull();
+    expect(objectDataToBuffer(42)).toBeNull();
+  });
+});
+
+describe('extractSignableDescriptors', () => {
+  it('pulls every nested descriptor out of a downloaded packet', () => {
+    const nested = extractSignableDescriptors(getPacketDescriptor());
+
+    expect(nested).toHaveLength(3);
+    nested.forEach(descriptor => {
+      expect(descriptor).toBeInstanceOf(DataDescriptor);
+      expect(descriptor.mimeType).toEqual('application/json');
+    });
+  });
+
+  it('returns an empty array when the descriptor holds a single blob', () => {
+    const plain = DataDescriptor.fromJson({
+      version: 1,
+      flags: 64,
+      mimetype: 'text/plain',
+      objectdata: Buffer.from('not a univalue', 'utf-8').toString('hex'),
+    });
+
+    expect(extractSignableDescriptors(plain)).toEqual([]);
+    expect(extractSignableDescriptors(new DataDescriptor())).toEqual([]);
+  });
+});
+
+describe('describeSignableObject', () => {
+  it('parses the JSON payload and hashes the exact bytes to be signed', () => {
+    const objects = extractSignableDescriptors(getPacketDescriptor()).map(describeSignableObject);
+
+    expect(objects.map(object => object.json.message)).toEqual([
+      'Great collaborator',
+      'Great collaborator2',
+      'Great collaborator3',
+    ]);
+
+    objects.forEach((object, index) => {
+      expect(object.index).toEqual(index);
+      expect(object.json.endorsee).toEqual(SIGNING_ID);
+      expect(object.hash).toEqual(
+        createHash('sha256').update(object.descriptor.toBuffer()).digest('hex'),
+      );
+    });
+
+    // Distinct payloads must not collapse to the same signature subject.
+    expect(new Set(objects.map(object => object.hash)).size).toEqual(3);
+  });
+
+  it('orders fields for display and keeps unknown keys', () => {
+    const descriptor = DataDescriptor.fromJson({
+      version: 1,
+      flags: 64,
+      mimetype: 'application/json',
+      objectdata: Buffer.from(
+        JSON.stringify({ version: 1, txid: 'ab', message: 'hi', extra: 'kept' }),
+        'utf-8',
+      ).toString('hex'),
+    });
+
+    const object = describeSignableObject(descriptor, 0);
+
+    expect(object.fields.map(field => field.key)).toEqual(['message', 'txid', 'extra']);
+    expect(object.fields[0].label).toEqual('Message');
+    expect(object.fields[2].label).toEqual('Extra');
+  });
+
+  it('falls back to text for non-JSON payloads', () => {
+    const descriptor = DataDescriptor.fromJson({
+      version: 1,
+      flags: 64,
+      mimetype: 'text/plain',
+      objectdata: Buffer.from('I agree to the terms', 'utf-8').toString('hex'),
+    });
+
+    const object = describeSignableObject(descriptor, 2);
+
+    expect(object.json).toBeNull();
+    expect(object.text).toEqual('I agree to the terms');
+    expect(object.fields).toEqual([]);
+    expect(getSignableObjectTitle(object)).toEqual('I agree to the terms');
+  });
+});
+
+describe('getSignableObjectTitle', () => {
+  it('prefers a resolved label, then the message, then a positional fallback', () => {
+    const [object] = extractSignableDescriptors(getPacketDescriptor()).map(describeSignableObject);
+
+    expect(getSignableObjectTitle(object, 'Endorsement')).toEqual('Endorsement');
+    expect(getSignableObjectTitle(object)).toEqual('Great collaborator');
+
+    const empty = describeSignableObject(new DataDescriptor(), 4);
+    expect(getSignableObjectTitle(empty)).toEqual('Object 5');
+  });
+});
+
+describe('multi signature response', () => {
+  // Mirrors signAndCreateResponse in DataPacketRequestInfo: one SignatureData
+  // per selected object, emitted next to the bytes it covers.
+  const buildResponse = (objects, details) => {
+    const values = [];
+
+    for (const object of objects) {
+      const sigData = new SignatureData({
+        version: new BN(1),
+        systemID: SYSTEM_ID,
+        identityID: SIGNING_ID,
+        signatureHash: createHash('sha256').update(object.buffer).digest(),
+        hashType: new BN(5),
+        sigType: new BN(1),
+      });
+      // Stand-in for the signHash RPC result.
+      sigData.signatureAsVch = Buffer.alloc(65, object.index + 1);
+
+      values.push({ [VDXF_Data.DataDescriptorKey.vdxfid]: object.descriptor });
+      values.push({ [VDXF_Data.SignatureDataKey.vdxfid]: sigData });
+    }
+
+    const responseDetails = new DataResponseDetails({
+      data: DataDescriptor.fromJson({
+        version: 1,
+        flags: 2,
+        objectdata: new VdxfUniValue({ values }).toBuffer().toString('hex'),
+        salt: Buffer.alloc(32, 9).toString('hex'),
+      }),
+      requestID: details.requestID,
+    });
+
+    const response = new GenericResponse();
+    response.details = [new DataResponseOrdinalVDXFObject({ data: responseDetails })];
+    response.requestID = details.requestID;
+    response.signature = new VerifiableSignatureData({
+      systemID: CompactAddressObject.fromIAddress(SYSTEM_ID),
+      identityID: CompactAddressObject.fromIAddress(SIGNING_ID),
+    });
+    response.signature.signatureAsVch = Buffer.alloc(65, 1);
+    response.setSigned();
+    response.setFlags();
+
+    return response;
+  };
+
+  const readSignedPairs = (response) => {
+    const uniValue = new VdxfUniValue();
+    uniValue.fromBuffer(response.details[0].data.data.objectdata);
+
+    const pairs = [];
+    let pendingDescriptor = null;
+
+    for (const value of uniValue.values) {
+      const descriptor = value[VDXF_Data.DataDescriptorKey.vdxfid];
+      if (descriptor) pendingDescriptor = descriptor;
+
+      const signature = value[VDXF_Data.SignatureDataKey.vdxfid];
+      if (signature && pendingDescriptor) {
+        pairs.push({ descriptor: pendingDescriptor, signature });
+        pendingDescriptor = null;
+      }
+    }
+
+    return pairs;
+  };
+
+  it('confirms the request asks for the user signature over downloaded data', () => {
+    const details = getRequestDetails();
+
+    expect(
+      details.flags.and(DataPacketRequestDetails.FLAG_FOR_USERS_SIGNATURE).gt(new BN(0)),
+    ).toBe(true);
+    expect(
+      details.flags.and(DataPacketRequestDetails.FLAG_HAS_URL_FOR_DOWNLOAD).gt(new BN(0)),
+    ).toBe(true);
+    expect(details.statements).toEqual(['ValuVerse Endorsements']);
+  });
+
+  it('carries one signature per object and survives a serialization roundtrip', () => {
+    const details = getRequestDetails();
+    const objects = extractSignableDescriptors(getPacketDescriptor()).map(describeSignableObject);
+
+    const buffer = buildResponse(objects, details).toBuffer();
+
+    const restored = new GenericResponse();
+    restored.fromBuffer(buffer);
+    expect(restored.toBuffer().toString('hex')).toEqual(buffer.toString('hex'));
+
+    const pairs = readSignedPairs(restored);
+    expect(pairs).toHaveLength(3);
+
+    // Each signature must cover the descriptor it is paired with.
+    pairs.forEach((pair, index) => {
+      expect(pair.signature.signatureHash.toString('hex')).toEqual(objects[index].hash);
+      expect(
+        createHash('sha256').update(pair.descriptor.toBuffer()).digest('hex'),
+      ).toEqual(objects[index].hash);
+      expect(pair.signature.identityID).toEqual(SIGNING_ID);
+    });
+
+    expect(restored.requestID.toIAddress()).toEqual(details.requestID.toIAddress());
+  });
+
+  it('only signs the objects the user selected', () => {
+    const details = getRequestDetails();
+    const objects = extractSignableDescriptors(getPacketDescriptor()).map(describeSignableObject);
+    const selected = objects.filter(object => [0, 2].includes(object.index));
+
+    const pairs = readSignedPairs(buildResponse(selected, details));
+
+    expect(pairs).toHaveLength(2);
+    expect(pairs.map(pair => pair.signature.signatureHash.toString('hex'))).toEqual([
+      objects[0].hash,
+      objects[2].hash,
+    ]);
+  });
+});

--- a/src/utils/deeplink/signableObjects.js
+++ b/src/utils/deeplink/signableObjects.js
@@ -1,0 +1,153 @@
+/**
+ * Helpers for the signable objects carried by a downloaded data packet.
+ *
+ * When a DataPacketRequestDetails sets FLAG_HAS_URL_FOR_DOWNLOAD the URL does
+ * not have to resolve to a single blob. It can resolve to a DataDescriptor
+ * whose objectdata is a VdxfUniValue holding one nested DataDescriptor per
+ * object the user is being asked to sign - for example a batch of
+ * endorsements. Each nested descriptor is a self contained object that gets
+ * its own signature, which is what lets one request produce several
+ * signatures.
+ */
+import { DataDescriptor, VdxfUniValue } from 'verus-typescript-primitives';
+import * as VDXF_Data from 'verus-typescript-primitives/dist/vdxf/vdxfdatakeys';
+import { capitalizeString } from '../stringUtils';
+const createHash = require('create-hash');
+
+// Field order and labels used when a signable object is JSON. Endorsements are
+// the first consumer of this flow; anything else falls back to the raw key.
+const JSON_FIELD_LABELS = {
+  endorsee: 'Endorsee',
+  endorser: 'Endorser',
+  message: 'Message',
+  reference: 'Reference',
+  txid: 'Transaction ID',
+  version: 'Version',
+};
+
+const JSON_FIELD_ORDER = ['message', 'endorsee', 'endorser', 'reference', 'txid'];
+
+/**
+ * Coerces the many shapes objectdata arrives in (hex string, Buffer, or the
+ * JSON serialised form of a Buffer) into a Buffer.
+ * @param {string | Buffer | { type: string, data: Array<number> }} objectdata
+ * @returns {Buffer | null}
+ */
+export const objectDataToBuffer = (objectdata) => {
+  if (objectdata == null) return null;
+  if (Buffer.isBuffer(objectdata)) return objectdata;
+  if (typeof objectdata === 'string') return Buffer.from(objectdata, 'hex');
+  if (objectdata.type === 'Buffer' && Array.isArray(objectdata.data)) {
+    return Buffer.from(objectdata.data);
+  }
+  return null;
+};
+
+/**
+ * Pulls the nested DataDescriptors out of a downloaded packet descriptor.
+ * Returns an empty array when the descriptor is not a multi object packet, so
+ * callers can fall through to their single blob handling.
+ * @param {DataDescriptor} descriptor
+ * @returns {Array<DataDescriptor>}
+ */
+export const extractSignableDescriptors = (descriptor) => {
+  const dataBuffer = objectDataToBuffer(descriptor?.objectdata);
+
+  if (!dataBuffer || dataBuffer.length === 0) return [];
+
+  try {
+    const uniValue = new VdxfUniValue();
+    uniValue.fromBuffer(dataBuffer);
+
+    if (!uniValue.values || uniValue.values.length === 0) return [];
+
+    const descriptorKey = VDXF_Data.DataDescriptorKey.vdxfid;
+    const nested = [];
+
+    for (const valueItem of uniValue.values) {
+      if (!valueItem || typeof valueItem !== 'object') continue;
+
+      const value = valueItem[descriptorKey];
+      if (value instanceof DataDescriptor) nested.push(value);
+    }
+
+    return nested;
+  } catch (e) {
+    // Not a VdxfUniValue - the caller handles the packet as a single object.
+    return [];
+  }
+};
+
+/**
+ * Builds the display and signing payload for one signable object.
+ *
+ * `buffer` is the exact serialisation of the nested descriptor and is what
+ * gets hashed and signed, so the requester can verify a signature against the
+ * bytes it published.
+ * @param {DataDescriptor} descriptor
+ * @param {number} index
+ */
+export const describeSignableObject = (descriptor, index) => {
+  const buffer = descriptor.toBuffer();
+  const mimeType = descriptor.mimeType || '';
+  const contentBuffer = objectDataToBuffer(descriptor.objectdata);
+
+  let json = null;
+  let text = null;
+
+  if (contentBuffer) {
+    if (mimeType === 'application/json') {
+      try {
+        json = JSON.parse(contentBuffer.toString('utf-8'));
+      } catch (e) {
+        text = contentBuffer.toString('utf-8');
+      }
+    } else if (mimeType.startsWith('text/')) {
+      text = contentBuffer.toString('utf-8');
+    }
+  }
+
+  return {
+    index,
+    descriptor,
+    buffer,
+    mimeType,
+    label: descriptor.label || '',
+    json,
+    text,
+    fields: json ? buildJsonFields(json) : [],
+    hash: createHash('sha256').update(buffer).digest('hex'),
+  };
+};
+
+/**
+ * Flattens a JSON signable object into ordered rows for display. Known keys
+ * come first in a readable order, then anything else the sender included.
+ * @param {object} json
+ * @returns {Array<{ key: string, label: string, value: string }>}
+ */
+const buildJsonFields = (json) => {
+  const keys = Object.keys(json);
+  const ordered = [
+    ...JSON_FIELD_ORDER.filter(key => keys.includes(key)),
+    ...keys.filter(key => !JSON_FIELD_ORDER.includes(key) && key !== 'version'),
+  ];
+
+  return ordered.map(key => ({
+    key,
+    label: JSON_FIELD_LABELS[key] || capitalizeString(key),
+    value: typeof json[key] === 'object' ? JSON.stringify(json[key]) : String(json[key]),
+  }));
+};
+
+/**
+ * Short one line summary for a signable object, used as the row title.
+ * @param {ReturnType<typeof describeSignableObject>} object
+ * @param {string} [labelOverride] friendly name resolved from the signer's defined keys
+ */
+export const getSignableObjectTitle = (object, labelOverride) => {
+  if (labelOverride) return labelOverride;
+  if (object.json?.message) return object.json.message;
+  if (object.text) return object.text.slice(0, 80);
+  return `Object ${object.index + 1}`;
+};


### PR DESCRIPTION
## Summary

A `FLAG_HAS_URL_FOR_DOWNLOAD` packet no longer has to describe a single blob. The URL may resolve to a `DataDescriptor` whose `objectdata` is a `VdxfUniValue` holding **one nested `DataDescriptor` per object the user is asked to sign**. A batch of endorsements is the first use of this shape.

```
DataDescriptor                       (downloaded from URLRef.url, hash-verified)
 ├─ label: "ValuVerse Endorsements"
 └─ objectdata: VdxfUniValue
      ├─ [DataDescriptorKey] DataDescriptor  mimetype application/json  → endorsement 1
      ├─ [DataDescriptorKey] DataDescriptor  mimetype application/json  → endorsement 2
      └─ [DataDescriptorKey] DataDescriptor  mimetype application/json  → endorsement 3
```

## Changes

- **New `src/utils/deeplink/signableObjects.js`** — extracts the nested descriptors, coerces `objectdata` across the several shapes it arrives in (hex string, `Buffer`, JSON-serialised `Buffer`), and builds display rows for `application/json` and `text/*` payloads. Returns an empty array for a single-blob packet so callers fall through to existing behaviour.
- **Per-item review and selection** — each nested object is rendered for review; the nested `label` is resolved to a friendly name through the signer's `DefinedKey` content where possible. All items are selected by default, and continuing with none selected is rejected in both the continue guard and the detail rows.
- **One signature per selected object** — `signatureHash = SHA-256(nestedDescriptor.toBuffer())`, then the usual VerusID identity hash (`version 2`, `hash_type 5`, current height) and `signHash`.
- **Response layout** — all signatures ride in one `DataResponseDetails`, inside a single `VdxfUniValue` as interleaved `[DataDescriptorKey, SignatureDataKey]` pairs. Each signature immediately follows the exact bytes it covers, so the requester can attribute a signature without reconstructing the downloaded packet byte for byte.
- **Backwards compatible** — when the packet holds no nested descriptors, the whole `DataPacketRequestDetails` buffer is signed, exactly as before.
- **Docs** — new section 10 in `docs/datapackettestmobile.md` covering the packet shape, wallet behaviour, and response layout.

## Testing

11 new unit tests in `src/utils/__tests__/unit/signableObjects.unit.test.js` cover buffer coercion, nested-descriptor extraction, JSON field ordering, title fallbacks, and the multi-signature response — including a serialization roundtrip and that only selected objects are signed.

> [!NOTE]
> The repo's jest setup is currently broken on `max_newsend_integration` independently of this PR: `jest@26.6.3` is installed alongside a hoisted `jest-environment-node@29.7.0` (react-native 0.71's preset expects jest 29), so **all 10 pre-existing suites** fail to run with `TypeError: Cannot read properties of undefined (reading 'testEnvironmentOptions')`. Pointing `testEnvironment` at the nested v26 copy runs the suite, and all 11 tests pass:
>
> ```
> npx jest --config '{"testEnvironment":"./node_modules/jest-config/node_modules/jest-environment-node","rootDir":".","testMatch":["**/signableObjects.unit.test.js"],"transform":{"^.+\\.js$":"babel-jest"},"transformIgnorePatterns":["node_modules/(?!(verus-typescript-primitives)/)"]}'
> ```
>
> Fixing the jest version mismatch is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)